### PR TITLE
Avoid using Proc.status

### DIFF
--- a/lib/TAP.pm
+++ b/lib/TAP.pm
@@ -101,7 +101,7 @@ class Result {
         $!exit-status.defined ?? $!exit-status.exitcode !! Int;
     }
     method wait() {
-        $!exit-status.defined ?? $!exit-status.status !! Int;
+        $!exit-status.defined ?? ($!exit-status.exitcode +< 8) +| $!exit-status.signal !! Int;
     }
 
     method has-problems($ignore-exit) {


### PR DESCRIPTION
This method has been deprecated. Instead we now use `Proc.exitcode` and `Proc.signal` to recreate the value.

This is more of a short-term fix, at a later point I want to rewrite it much like [this](https://github.com/Perl-Toolchain-Gang/Test-Harness/pull/106), so that it won't need this weird value anymore.